### PR TITLE
for now, should disallow google from indexing site until it's ready

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+


### PR DESCRIPTION
Justin, from an SEO perspective, we don't want google to somehow index this site while it has lorum ipsum type content. If it did that, then it might get displayed in google search results when the site comes up. 

I've put a robots.txt file here that will guide google to ignore the site for now. We can remove this file when we are ready to start doing SEO related stuff.

What do you think?