### PR TITLE
Add Code of Conduct.

### DIFF
--- a/about.html
+++ b/about.html
@@ -142,6 +142,94 @@ testimonials:
 </div>
 
 <div class='full'>
+  <div class='row'>
+    <div class='medium-12 columns'>
+      <h2>Code of Conduct</h2>
+      <p>This code of conduct outlines our expectations for participants
+        within the <strong>Roaring Fork Technologists</strong> community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.</p>
+
+        <p>Our open source community strives to:</p>
+
+        <ul>
+          <li><strong>Be friendly and patient.</strong></li>
+          <li><strong>Be welcoming</strong>: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.</li>
+          <li><strong>Be considerate</strong>: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we’re a world-wide community, so you might not be communicating in someone else’s primary language.</li>
+          <li><strong>Be respectful</strong>:  Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one.</li>
+          <li><strong>Be careful in the words that we choose</strong>: we are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren’t acceptable.</li>
+          <li><strong>Try to understand why we disagree</strong>: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.</li>
+        </ul>
+
+        <h3 id="definitions">Definitions</h3>
+
+        <p>Harassment includes, but is not limited to:</p>
+
+        <ul>
+          <li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation</li>
+          <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment</li>
+          <li>Deliberate misgendering. This includes deadnaming or persistently using a pronoun that does not correctly reflect a person’s gender identity. You must address people by the name they give you when not addressing them by their username or handle</li>
+          <li>Physical contact and simulated physical contact (eg, textual descriptions like “<em>hug</em>” or “<em>backrub</em>”) without consent or after a request to stop</li>
+          <li>Threats of violence, both physical and psychological</li>
+          <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
+          <li>Deliberate intimidation</li>
+          <li>Stalking or following</li>
+          <li>Harassing photography or recording, including logging online activity for harassment purposes</li>
+          <li>Sustained disruption of discussion</li>
+          <li>Unwelcome sexual attention, including gratuitous or off-topic sexual images or behaviour</li>
+          <li>Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others</li>
+          <li>Continued one-on-one communication after requests to cease</li>
+          <li>Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse</li>
+          <li>Publication of non-harassing private communication</li>
+        </ul>
+
+        <p>Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:</p>
+
+        <ul>
+          <li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
+          <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”</li>
+          <li>Refusal to explain or debate social justice concepts</li>
+          <li>Communicating in a ‘tone’ you don’t find congenial</li>
+          <li>Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions</li>
+        </ul>
+
+        <h3 id="diversity-statement">Diversity Statement</h3>
+
+        <p>We encourage everyone to participate and are committed to building a community for all. Although we will fail at times, we seek to treat everyone both as fairly and equally as possible. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.</p>
+
+        <p>Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected
+        characteristics above, including participants with disabilities.</p>
+
+        <h3 id="reporting-issues">Reporting Issues</h3>
+
+        <p>If you experience or witness unacceptable behavior—or have any other
+        concerns—please report it by contacting us via <strong>The contact page</strong>. All reports will be handled with discretion. In your report please include:</p>
+
+        <ul>
+          <li>Your contact information.</li>
+          <li>Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please
+            include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.</li>
+          <li>Any additional information that may be helpful.</li>
+        </ul>
+
+        <p>After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.</p>
+
+        <h3 id="attribution--acknowledgements">Attribution &amp; Acknowledgements</h3>
+
+        <p>We all stand on the shoulders of giants across many open source communities.  We’d like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:</p>
+
+        <ul>
+          <li><a href="http://todogroup.org/opencodeofconduct/">Todo</a></li>
+          <li><a href="https://www.djangoproject.com/conduct/reporting/">Django</a></li>
+          <li><a href="https://www.python.org/community/diversity/">Python</a></li>
+          <li><a href="http://www.ubuntu.com/about/about-ubuntu/conduct">Ubuntu</a></li>
+          <li><a href="http://contributor-covenant.org/">Contributor Covenant</a></li>
+          <li><a href="http://geekfeminism.org/about/code-of-conduct/">Geek Feminism</a></li>
+          <li><a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a></li>
+        </ul>
+    </div>
+  </div>
+</div>
+
+<div class='full'>
   <div class='four spacing'></div>
   <div class='row'>
     <div class='medium-12 columns'>


### PR DESCRIPTION
Adopted from the Open Code of Conduct template provided by [todogroup.org](http://todogroup.org/opencodeofconduct/).

